### PR TITLE
chore(docker): update Node.js and Alpine package versions in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,45 +1,29 @@
-FROM docker.io/library/node:22.13.1-alpine3.20@sha256:c52e20859a92b3eccbd3a36c5e1a90adc20617d8d421d65e8a622e87b5dac963
+FROM docker.io/library/node:22.13.1-alpine3.21@sha256:e2b39f7b64281324929257d0f8004fb6cb4bf0fdfb9aa8cedb235a766aec31da
 
 # renovate: datasource=repology depName=alpine_3_20/bash versioning=loose
-ENV BASH_VERSION="5.2.26-r0"
-
-# renovate: datasource=repology depName=alpine_3_20/busybox versioning=loose
-ENV BUSYBOX_VERSION="1.36.1-r29"
-
-# renovate: datasource=repology depName=alpine_3_20/c-ares versioning=loose
-ENV C_ARES_VERSION="1.33.1-r0"
+ENV BASH_VERSION="5.2.37-r0"
 
 # renovate: datasource=repology depName=alpine_3_20/curl versioning=loose
 ENV CURL_VERSION="8.12.0-r0"
 
-# renovate: datasource=repology depName=alpine_3_20/expat versioning=loose
-ENV EXPACT_VERSION="2.6.4-r0"
-
 # renovate: datasource=repology depName=alpine_3_20/git versioning=loose
-ENV GIT_VERSION="2.45.3-r0"
+ENV GIT_VERSION="2.47.2-r0"
 
 # renovate: datasource=repology depName=alpine_3_20/gnupg versioning=loose
-ENV GNUPG_VERSION="2.4.5-r0"
-
-# renovate: datasource=repology depName=alpine_3_20/libcrypto3 versioning=loose
-ENV LIBCRYPTO3_VERSION="3.3.2-r2"
+ENV GNUPG_VERSION="2.4.7-r0"
 
 # renovate: datasource=repology depName=alpine_3_20/libssl3 versioning=loose
-ENV LIBSSL3_VERSION="3.3.2-r2"
+ENV LIBSSL3_VERSION="3.3.2-r5"
 
 # renovate: datasource=repology depName=alpine_3_20/openssh versioning=loose
-ENV OPENSSH_VERSION="9.7_p1-r4"
+ENV OPENSSH_VERSION="9.9_p1-r2"
 
 RUN apk update && \
     apk add --no-cache \
     bash="${BASH_VERSION}" \
-    busybox="${BUSYBOX_VERSION}" \
-    c-ares="${C_ARES_VERSION}" \
     curl="${CURL_VERSION}" \
-    expat="${EXPACT_VERSION}" \
     git="${GIT_VERSION}" \
     gnupg="${GNUPG_VERSION}" \
-    libcrypto3="${LIBCRYPTO3_VERSION}" \
     libssl3="${LIBSSL3_VERSION}" \
     openssh="${OPENSSH_VERSION}"
 

--- a/renovate.json
+++ b/renovate.json
@@ -13,7 +13,7 @@
             "matchPackageNames": [
                 "docker.io/library/node"
             ],
-            "versionCompatibility": "^(?<version>[^-]+)(?<compatibility>-alpine3.20)?$",
+            "versionCompatibility": "^(?<version>[^-]+)(?<compatibility>-alpine3.21)?$",
             "versioning": "node"
         }
     ]


### PR DESCRIPTION
This pull request includes updates to the `Dockerfile` and `renovate.json` to upgrade the Alpine version used in the Node.js base image and several dependencies.

### Dockerfile updates:

* Updated the Node.js base image from `alpine3.20` to `alpine3.21` and the corresponding SHA256 hash.
* Updated the versions of several dependencies, including `bash`, `git`, `gnupg`, `libssl3`, and `openssh`. Removed the version specifications for `busybox`, `c-ares`, `expat`, and `libcrypto3` dependencies.

### Renovate configuration updates:

* Modified the `versionCompatibility` regex in `renovate.json` to match the new `alpine3.21` version.

Fixes #123 