### PR TITLE
chore: update Renovate configuration to use custom manager and remove…

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,8 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
-        "config:recommended",
         "customManagers:dockerfileVersions",
-        "group:all"
+        "github>juancarlosjr97/renovate-configuration#0.1.4"
     ],
     "packageRules": [
         {


### PR DESCRIPTION
This pull request includes a change to the `renovate.json` file to update the configuration for Renovate. The most important change is the modification of the `extends` property to use a custom configuration from a GitHub repository.

Configuration update:

* [`renovate.json`](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L4-R5): Removed the `"config:recommended"` and `"group:all"` configurations, and added `"github>juancarlosjr97/renovate-configuration#0.1.4"` to the `extends` property.