### PR TITLE
Fix broken docker build due to openssh-9.9_p1-r2 breaking compatability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,17 +15,13 @@ ENV GNUPG_VERSION="2.4.7-r0"
 # renovate: datasource=repology depName=alpine_3_20/libssl3 versioning=loose
 ENV LIBSSL3_VERSION="3.3.3-r0"
 
-# renovate: datasource=repology depName=alpine_3_20/openssh versioning=loose
-ENV OPENSSH_VERSION="9.9_p1-r2"
-
 RUN apk update && \
     apk add --no-cache \
     bash="${BASH_VERSION}" \
     curl="${CURL_VERSION}" \
     git="${GIT_VERSION}" \
     gnupg="${GNUPG_VERSION}" \
-    libssl3="${LIBSSL3_VERSION}" \
-    openssh="${OPENSSH_VERSION}"
+    libssl3="${LIBSSL3_VERSION}"
 
 WORKDIR /app
 


### PR DESCRIPTION
Related to #132

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/juancarlosjr97/release-it-containerized/pull/133?shareId=1a0a104b-6358-4541-afcf-97cf87f94e99).