### PR TITLE
Fix broken docker build due to openssh-9.9_p1-r2 breaking compatability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ENV GNUPG_VERSION="2.4.7-r0"
 ENV LIBSSL3_VERSION="3.3.3-r0"
 
 # renovate: datasource=repology depName=alpine_3_20/openssh versioning=loose
-ENV OPENSSH_VERSION="9.9_p1-r2"
+ENV OPENSSH_VERSION="9.9_p2-r0"
 
 RUN apk update && \
     apk add --no-cache \


### PR DESCRIPTION
Fixes #132

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/juancarlosjr97/release-it-containerized/pull/134?shareId=3a259062-85ba-40af-94b0-dcbe32d86aca).