### PR TITLE
Update Docker image c-ares to version 1.34.5-r0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,9 @@ ENV LIBSSL3_VERSION="3.3.3-r0"
 # renovate: datasource=repology depName=alpine_3_21/openssh versioning=loose
 ENV OPENSSH_VERSION="9.9_p2-r0"
 
+# renovate: datasource=repology depName=alpine_3_21/c-ares versioning=loose
+ENV CARES_VERSION="1.34.5-r0"
+
 RUN apk update && \
     apk add --no-cache \
     bash="${BASH_VERSION}" \
@@ -25,7 +28,8 @@ RUN apk update && \
     git="${GIT_VERSION}" \
     gnupg="${GNUPG_VERSION}" \
     libssl3="${LIBSSL3_VERSION}" \
-    openssh="${OPENSSH_VERSION}"
+    openssh="${OPENSSH_VERSION}" \
+    c-ares="${CARES_VERSION}"
 
 WORKDIR /app
 


### PR DESCRIPTION
Fixes #140

Update Dockerfile to include c-ares version 1.34.5-r0.

* Add `ENV CARES_VERSION="1.34.5-r0"` to define the c-ares version.
* Add `c-ares="${CARES_VERSION}"` in the `RUN apk update && \` section to install the specified version of c-ares.

