### PR TITLE
Add scan for image

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   release_options:
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success' && (github.event.workflow_run.head_branch == 'main' || github.event.workflow_run.head_branch == 'develop')
+    if: github.event.workflow_run.conclusion == 'success' && (github.event.workflow_run.head_branch == 'main' || github.event.workflow_run.head_branch == 'develop') && ${{ github.event_name != 'schedule' }}
     outputs:
       release_options: ${{ steps.release_options.outputs.release_options }}
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,7 @@ jobs:
 
   security:
     needs: build
-    uses: juancarlosjr97/github-actions-workflows-to-rule-them-all/.github/workflows/image-security.yml@ec50b4b94d832bee6e60cf5e969e2b9616840f66
+    uses: juancarlosjr97/github-actions-workflows-to-rule-them-all/.github/workflows/image-security.yml@da0aa266054b652c855be9bf75626a05c22e460f
     with:
       IMAGE_REFERENCE: ghcr.io/${{ github.repository }}:${{ github.sha }}
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -48,6 +48,15 @@ jobs:
     needs: security
     runs-on: ubuntu-latest
     steps:
+      - name: Download Docker image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.build.outputs.image_tar_artifact_name }}
+          path: .
+
+      - name: Load Docker image from TAR
+        run: docker load -i ${{ needs.build.outputs.image_tar_file_path }}
+
       - name: Running release-it on dry-run without GPG or SSH
         run: |
           docker run \

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,20 +17,21 @@ jobs:
         run: docker build --tag ghcr.io/${{ github.repository }}:${{ github.sha }} .
 
       - name: Save Docker image to tarball
-        run: docker save ghcr.io/${{ github.repository }}:${{ github.sha }} -o image.tar
+        run: docker save ghcr.io/${{ github.repository }}:${{ github.sha }} -o ${{ github.sha }}.tar
 
       - name: Upload image tarball as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: docker-image
-          path: image.tar
+          name: docker-image-${{ github.sha }}
+          path: ${{ github.sha }}.tar
 
   security:
     needs: build
-    uses: juancarlosjr97/github-actions-workflows-to-rule-them-all/.github/workflows/image-security.yml@a236a236011b532aa0d8ad7022d9e7f1ec0f55d9
+    uses: juancarlosjr97/github-actions-workflows-to-rule-them-all/.github/workflows/image-security.yml@4050a248a71d675feef6287cd0a018563b198d9e
     with:
       IMAGE_TAG: ghcr.io/${{ github.repository }}:${{ github.sha }}
-      IMAGE_TAR_ARTIFACT_NAME: docker-image
+      IMAGE_TAR_ARTIFACT_NAME: docker-image-${{ github.sha }}
+      IMAGE_TAR_FILE_PATH: ${{ github.sha }}.tar
 
   tests:
     needs: security

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,6 +7,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      image_reference: ${{ steps.build.outputs.image_reference }}
+      image_tar_artifact_name: ${{ steps.save.outputs.image_tar_artifact_name }}
+      image_tar_file_path: ${{ steps.save.outputs.image_tar_file_path }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -14,10 +18,17 @@ jobs:
           fetch-depth: 0
 
       - name: Build the Image
-        run: docker build --tag ghcr.io/${{ github.repository }}:${{ github.sha }} .
+        id: build
+        run: |
+          docker build --tag ghcr.io/${{ github.repository }}:${{ github.sha }} .
+          echo "image_reference=ghcr.io/${{ github.repository }}:${{ github.sha }}" >> $GITHUB_OUTPUT
 
       - name: Save Docker image to tarball
-        run: docker save ghcr.io/${{ github.repository }}:${{ github.sha }} -o ${{ github.sha }}.tar
+        id: save
+        run: |
+          docker save ghcr.io/${{ github.repository }}:${{ github.sha }} -o ${{ github.sha }}.tar
+          echo "image_tar_artifact_name=docker-image-${{ github.sha }}" >> $GITHUB_OUTPUT
+          echo "image_tar_file_path=${{ github.sha }}.tar" >> $GITHUB_OUTPUT
 
       - name: Upload image tarball as artifact
         uses: actions/upload-artifact@v4
@@ -29,9 +40,9 @@ jobs:
     needs: build
     uses: juancarlosjr97/github-actions-workflows-to-rule-them-all/.github/workflows/image-security.yml@4050a248a71d675feef6287cd0a018563b198d9e
     with:
-      IMAGE_REFERENCE: ghcr.io/${{ github.repository }}:${{ github.sha }}
-      IMAGE_TAR_ARTIFACT_NAME: docker-image-${{ github.sha }}
-      IMAGE_TAR_FILE_PATH: ${{ github.sha }}.tar
+      IMAGE_REFERENCE: ${{ needs.build.outputs.image_reference }}
+      IMAGE_TAR_ARTIFACT_NAME: ${{ needs.build.outputs.image_tar_artifact_name }}
+      IMAGE_TAR_FILE_PATH: ${{ needs.build.outputs.image_tar_file_path }}
 
   tests:
     needs: security

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,6 +16,11 @@ jobs:
       - name: Build the Image
         run: docker build --tag ghcr.io/${{ github.repository }}:${{ github.sha }} .
 
+      - name: Security Scan
+        uses: aquasecurity/trivy-action@0.30.0
+        with:
+          image-ref: ghcr.io/${{ github.repository }}:${{ github.sha }}
+
   security:
     needs: build
     uses: juancarlosjr97/github-actions-workflows-to-rule-them-all/.github/workflows/image-security.yml@a7af670705b29ab1c891d04671250341240a6ed6

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,16 +16,21 @@ jobs:
       - name: Build the Image
         run: docker build --tag ghcr.io/${{ github.repository }}:${{ github.sha }} .
 
-      - name: Security Scan
-        uses: aquasecurity/trivy-action@0.30.0
-        with:
-          image-ref: ghcr.io/${{ github.repository }}:${{ github.sha }}
-
   security:
-    needs: build
-    uses: juancarlosjr97/github-actions-workflows-to-rule-them-all/.github/workflows/image-security.yml@a7af670705b29ab1c891d04671250341240a6ed6
-    with:
-      IMAGE_REFERENCE: ghcr.io/${{ github.repository }}:${{ github.sha }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build the Image
+        run: docker build --tag ghcr.io/${{ github.repository }}:${{ github.sha }} .
+
+      - name: Run Security Workflow
+        uses: juancarlosjr97/github-actions-workflows-to-rule-them-all/.github/workflows/image-security.yml@a7af670705b29ab1c891d04671250341240a6ed6
+        with:
+          IMAGE_REFERENCE: ghcr.io/${{ github.repository }}:${{ github.sha }}
 
   tests:
     needs: security

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,7 @@ jobs:
 
   security:
     needs: build
-    uses: juancarlosjr97/github-actions-workflows-to-rule-them-all/.github/workflows/image-security.yml@da0aa266054b652c855be9bf75626a05c22e460f
+    uses: juancarlosjr97/github-actions-workflows-to-rule-them-all/.github/workflows/image-security.yml@a7af670705b29ab1c891d04671250341240a6ed6
     with:
       IMAGE_REFERENCE: ghcr.io/${{ github.repository }}:${{ github.sha }}
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,20 +17,13 @@ jobs:
         run: docker build --tag ghcr.io/${{ github.repository }}:${{ github.sha }} .
 
   security:
+    needs: build
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - name: Security Scan
+        uses: aquasecurity/trivy-action@0.30.0
         with:
-          fetch-depth: 0
-
-      - name: Build the Image
-        run: docker build --tag ghcr.io/${{ github.repository }}:${{ github.sha }} .
-
-      - name: Run Security Workflow
-        uses: juancarlosjr97/github-actions-workflows-to-rule-them-all/.github/workflows/image-security.yml@a7af670705b29ab1c891d04671250341240a6ed6
-        with:
-          IMAGE_REFERENCE: ghcr.io/${{ github.repository }}:${{ github.sha }}
+          image-ref: ghcr.io/${{ github.repository }}:${{ github.sha }}
 
   tests:
     needs: security

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,14 +16,21 @@ jobs:
       - name: Build the Image
         run: docker build --tag ghcr.io/${{ github.repository }}:${{ github.sha }} .
 
+      - name: Save Docker image to tarball
+        run: docker save ghcr.io/${{ github.repository }}:${{ github.sha }} -o image.tar
+
+      - name: Upload image tarball as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-image
+          path: image.tar
+
   security:
     needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Security Scan
-        uses: aquasecurity/trivy-action@0.30.0
-        with:
-          image-ref: ghcr.io/${{ github.repository }}:${{ github.sha }}
+    uses: juancarlosjr97/github-actions-workflows-to-rule-them-all/.github/workflows/image-security.yml@a236a236011b532aa0d8ad7022d9e7f1ec0f55d9
+    with:
+      IMAGE_TAG: ghcr.io/${{ github.repository }}:${{ github.sha }}
+      IMAGE_TAR_ARTIFACT_NAME: docker-image
 
   tests:
     needs: security

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,7 +45,7 @@ jobs:
       IMAGE_TAR_FILE_PATH: ${{ needs.build.outputs.image_tar_file_path }}
 
   tests:
-    needs: security
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - name: Download Docker image artifact

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,7 +29,7 @@ jobs:
     needs: build
     uses: juancarlosjr97/github-actions-workflows-to-rule-them-all/.github/workflows/image-security.yml@4050a248a71d675feef6287cd0a018563b198d9e
     with:
-      IMAGE_TAG: ghcr.io/${{ github.repository }}:${{ github.sha }}
+      IMAGE_REFERENCE: ghcr.io/${{ github.repository }}:${{ github.sha }}
       IMAGE_TAR_ARTIFACT_NAME: docker-image-${{ github.sha }}
       IMAGE_TAR_FILE_PATH: ${{ github.sha }}.tar
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,7 +5,7 @@ on:
     branches:
 
 jobs:
-  test:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -16,11 +16,16 @@ jobs:
       - name: Build the Image
         run: docker build --tag ghcr.io/${{ github.repository }}:${{ github.sha }} .
 
-      - name: Security
-        uses: juancarlosjr97/github-actions-workflows-to-rule-them-all/.github/workflows/image-security.yml@ec50b4b94d832bee6e60cf5e969e2b9616840f66
-        with:
-          IMAGE_REFERENCE: ghcr.io/${{ github.repository }}:${{ github.sha }}
+  security:
+    needs: build
+    uses: juancarlosjr97/github-actions-workflows-to-rule-them-all/.github/workflows/image-security.yml@ec50b4b94d832bee6e60cf5e969e2b9616840f66
+    with:
+      IMAGE_REFERENCE: ghcr.io/${{ github.repository }}:${{ github.sha }}
 
+  tests:
+    needs: security
+    runs-on: ubuntu-latest
+    steps:
       - name: Running release-it on dry-run without GPG or SSH
         run: |
           docker run \

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,19 +14,24 @@ jobs:
           fetch-depth: 0
 
       - name: Build the Image
-        run: docker build --tag ghcr.io/${{ github.repository	}}:${{ github.sha }} .
+        run: docker build --tag ghcr.io/${{ github.repository }}:${{ github.sha }} .
+
+      - name: Security
+        uses: juancarlosjr97/github-actions-workflows-to-rule-them-all/.github/workflows/image-security.yml@ec50b4b94d832bee6e60cf5e969e2b9616840f66
+        with:
+          IMAGE_REFERENCE: ghcr.io/${{ github.repository }}:${{ github.sha }}
 
       - name: Running release-it on dry-run without GPG or SSH
         run: |
           docker run \
-          -e GITHUB_TOKEN=${GITHUB_TOKEN} \
-          -e GIT_DIRECTORY="/app" \
-          -e GIT_EMAIL=${GIT_EMAIL} \
-          -e GIT_USERNAME="${GIT_USERNAME}" \
-          -e RELEASE_IT_PLUGINS="@release-it/conventional-changelog@latest,@release-it/bumper@latest" \
-          -v $PWD:/app \
-          ghcr.io/${{ github.repository	}}:${{ github.sha }} \
-          release-it --dry-run --ci
+            -e GITHUB_TOKEN=${GITHUB_TOKEN} \
+            -e GIT_DIRECTORY="/app" \
+            -e GIT_EMAIL=${GIT_EMAIL} \
+            -e GIT_USERNAME="${GIT_USERNAME}" \
+            -e RELEASE_IT_PLUGINS="@release-it/conventional-changelog@latest,@release-it/bumper@latest" \
+            -v $PWD:/app \
+            ghcr.io/${{ github.repository }}:${{ github.sha }} \
+            release-it --dry-run --ci
         env:
           GIT_EMAIL: ${{ vars.GIT_EMAIL }}
           GIT_USERNAME: ${{ vars.GIT_USERNAME }}
@@ -35,16 +40,16 @@ jobs:
       - name: Running release-it on dry-run with GPG and without SSH
         run: |
           docker run \
-          -e GITHUB_TOKEN=${GITHUB_TOKEN} \
-          -e GIT_DIRECTORY="/app" \
-          -e GIT_EMAIL=${GIT_EMAIL} \
-          -e GIT_USERNAME="${GIT_USERNAME}" \
-          -e GPG_PRIVATE_KEY="${GPG_PRIVATE_KEY}" \
-          -e GPG_PRIVATE_KEY_ID="${GPG_PRIVATE_KEY_ID}" \
-          -e RELEASE_IT_PLUGINS="@release-it/conventional-changelog@latest,@release-it/bumper@latest" \
-          -v $PWD:/app \
-          ghcr.io/${{ github.repository	}}:${{ github.sha }} \
-          release-it --dry-run --ci
+            -e GITHUB_TOKEN=${GITHUB_TOKEN} \
+            -e GIT_DIRECTORY="/app" \
+            -e GIT_EMAIL=${GIT_EMAIL} \
+            -e GIT_USERNAME="${GIT_USERNAME}" \
+            -e GPG_PRIVATE_KEY="${GPG_PRIVATE_KEY}" \
+            -e GPG_PRIVATE_KEY_ID="${GPG_PRIVATE_KEY_ID}" \
+            -e RELEASE_IT_PLUGINS="@release-it/conventional-changelog@latest,@release-it/bumper@latest" \
+            -v $PWD:/app \
+            ghcr.io/${{ github.repository }}:${{ github.sha }} \
+            release-it --dry-run --ci
         env:
           GITHUB_TOKEN: ${{ secrets.PROJECT_GITHUB_TOKEN }}
           GIT_EMAIL: ${{ vars.GIT_EMAIL }}
@@ -55,17 +60,17 @@ jobs:
       - name: Running release-it on dry-run with GPG and SSH
         run: |
           docker run \
-          -e GITHUB_TOKEN=${GITHUB_TOKEN} \
-          -e GIT_DIRECTORY="/app" \
-          -e GIT_EMAIL=${GIT_EMAIL} \
-          -e GIT_USERNAME="${GIT_USERNAME}" \
-          -e GPG_PRIVATE_KEY="${GPG_PRIVATE_KEY}" \
-          -e GPG_PRIVATE_KEY_ID="${GPG_PRIVATE_KEY_ID}" \
-          -e RELEASE_IT_PLUGINS="@release-it/conventional-changelog@latest,@release-it/bumper@latest" \
-          -e SSH_PRIVATE_KEY="${SSH_PRIVATE_KEY}" \
-          -v $PWD:/app \
-          ghcr.io/${{ github.repository	}}:${{ github.sha }} \
-          release-it --dry-run --ci
+            -e GITHUB_TOKEN=${GITHUB_TOKEN} \
+            -e GIT_DIRECTORY="/app" \
+            -e GIT_EMAIL=${GIT_EMAIL} \
+            -e GIT_USERNAME="${GIT_USERNAME}" \
+            -e GPG_PRIVATE_KEY="${GPG_PRIVATE_KEY}" \
+            -e GPG_PRIVATE_KEY_ID="${GPG_PRIVATE_KEY_ID}" \
+            -e RELEASE_IT_PLUGINS="@release-it/conventional-changelog@latest,@release-it/bumper@latest" \
+            -e SSH_PRIVATE_KEY="${SSH_PRIVATE_KEY}" \
+            -v $PWD:/app \
+            ghcr.io/${{ github.repository }}:${{ github.sha }} \
+            release-it --dry-run --ci
         env:
           GITHUB_TOKEN: ${{ secrets.PROJECT_GITHUB_TOKEN }}
           GIT_EMAIL: ${{ vars.GIT_EMAIL }}
@@ -86,4 +91,3 @@ jobs:
           image_tag: ${{ github.sha }}
           plugins_list: "@release-it/conventional-changelog@latest,@release-it/bumper@latest"
           ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}
-  

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,7 +38,7 @@ jobs:
 
   security:
     needs: build
-    uses: juancarlosjr97/github-actions-workflows-to-rule-them-all/.github/workflows/image-security.yml@4050a248a71d675feef6287cd0a018563b198d9e
+    uses: juancarlosjr97/github-actions-workflows-to-rule-them-all/.github/workflows/shared-docker-security.yml@65a93d822ea0ed5d4291b4aae5589f748a3624fa
     with:
       IMAGE_REFERENCE: ${{ needs.build.outputs.image_reference }}
       IMAGE_TAR_ARTIFACT_NAME: ${{ needs.build.outputs.image_tar_artifact_name }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -48,6 +48,11 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          fetch-depth: 0
+
       - name: Download Docker image artifact
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,6 +3,8 @@ name: Test
 on:
   push:
     branches:
+  schedule:
+    - cron: '0 */6 * * *'
 
 jobs:
   build:


### PR DESCRIPTION
This pull request introduces enhancements to the GitHub Actions workflows, focusing on improving the release process, adding a scheduled build trigger, and incorporating Docker image handling. The key changes include refining conditional logic in the release workflow, adding a cron-based schedule for tests, and restructuring the test workflow to include Docker image build, save, and artifact upload steps.

### Workflow Enhancements:

* **Refined release workflow conditions**: Updated the `if` condition in `.github/workflows/release.yaml` to exclude scheduled events (`schedule`) from triggering the release workflow. This ensures that only relevant events trigger the release process.

* **Scheduled builds**: Added a cron-based schedule (`0 */6 * * *`) to `.github/workflows/test.yaml` to trigger builds every six hours. This ensures periodic testing and validation of the codebase.

### Docker Image Handling:

* **Build and save Docker images**: Modified the test workflow in `.github/workflows/test.yaml` to build Docker images, save them as tarball artifacts, and upload them for further use. This includes the addition of `build`, `save`, and `upload-artifact` steps, along with outputs for referencing the image and tarball.

* **Security and tests jobs**: Introduced `security` and `tests` jobs in `.github/workflows/test.yaml`. The `security` job uses a shared workflow to perform security checks on the Docker image, while the `tests` job downloads the image artifact, loads it, and prepares it for testing. Both jobs depend on the `build` job.