### PR TITLE
fix: pin actions/checkout to v5.0.1 in workflows and update renovate …

### DIFF
--- a/.github/workflows/local-test-workflow.yaml
+++ b/.github/workflows/local-test-workflow.yaml
@@ -34,7 +34,7 @@ jobs:
       image_tar_file_path: ${{ steps.save.outputs.image_tar_file_path }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        uses: actions/checkout@v5.0.1
         with:
           fetch-depth: 0
 
@@ -81,7 +81,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        uses: actions/checkout@v5.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -18,7 +18,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        uses: actions/checkout@v5.0.1
 
       - name: Log in to the Container registry
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ jobs:
     needs: release_options
     steps:
       - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        uses: actions/checkout@v5.0.1
         with:
           fetch-depth: 0
           ref: ${{ github.event.workflow_run.head_branch }}

--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,13 @@
             ],
             "versionCompatibility": "^(?<version>[^-]+)(?<compatibility>-alpine3.21)?$",
             "versioning": "node"
+        },
+        {
+            "description": "Pin actions/checkout to v5 until container actions support v6 credential storage",
+            "matchPackageNames": [
+                "actions/checkout"
+            ],
+            "allowedVersions": "<6.0.0"
         }
     ]
 }


### PR DESCRIPTION
Relates to #212 